### PR TITLE
Don't barf if PAGER="less -R"

### DIFF
--- a/ghc-core.cabal
+++ b/ghc-core.cabal
@@ -1,5 +1,5 @@
 name:           ghc-core
-version:        0.5.6
+version:        0.5.7
 license:        BSD3
 license-file:   LICENSE
 author:         Don Stewart

--- a/ghc-core.hs
+++ b/ghc-core.hs
@@ -128,11 +128,11 @@ main = do
 
 showInPager :: FilePath -> IO ExitCode
 showInPager file = do
-    pager <- maybe "less -R" (maybeAddOpts . words) <$> getEnvMaybe "PAGER"
-    system (pager ++ " " ++ file)
+    (pager:opts) <- maybe ["less", "-R"] (maybeAddOpts . words) <$> getEnvMaybe "PAGER"
+    rawSystem pager (opts ++ [file])
   where
-    maybeAddOpts ("less":opts) | "-R" `elem` opts = unwords ("less":opts)
-    maybeAddOpts pager                            = unwords pager
+    maybeAddOpts ("less":opts) = "less" : if "-R" `elem` opts then opts else "-R":opts
+    maybeAddOpts pager         = pager
 
 --
 -- Clean up the output with some regular expressions.

--- a/ghc-core.hs
+++ b/ghc-core.hs
@@ -128,10 +128,11 @@ main = do
 
 showInPager :: FilePath -> IO ExitCode
 showInPager file = do
-    mv <- getEnvMaybe "PAGER"
-    let pager = fromMaybe "less" mv
-        pagerOpts = if pager == "less" then ["-R"] else []
-    rawSystem pager (pagerOpts ++ [file])
+    (pager:opts) <- maybe ["less", "-R"] (addOpts . words) <$> getEnvMaybe "PAGER"
+    rawSystem pager (opts ++ [file])
+  where
+    addOpts ("less":opts) | "-R" `elem` opts = "less":opts
+    addOpts _                                = ["less", "-R"] 
 
 --
 -- Clean up the output with some regular expressions.

--- a/ghc-core.hs
+++ b/ghc-core.hs
@@ -128,11 +128,11 @@ main = do
 
 showInPager :: FilePath -> IO ExitCode
 showInPager file = do
-    pager <- maybe "less -R" (addOpts . words) <$> getEnvMaybe "PAGER"
+    pager <- maybe "less -R" (maybeAddOpts . words) <$> getEnvMaybe "PAGER"
     system (pager ++ " " ++ file)
   where
-    addOpts ("less":opts) | "-R" `elem` opts = unwords ("less":opts)
-    addOpts _                                = "less -R"
+    maybeAddOpts ("less":opts) | "-R" `elem` opts = unwords ("less":opts)
+    maybeAddOpts pager                            = unwords pager
 
 --
 -- Clean up the output with some regular expressions.

--- a/ghc-core.hs
+++ b/ghc-core.hs
@@ -128,11 +128,11 @@ main = do
 
 showInPager :: FilePath -> IO ExitCode
 showInPager file = do
-    (pager:opts) <- maybe ["less", "-R"] (addOpts . words) <$> getEnvMaybe "PAGER"
-    rawSystem pager (opts ++ [file])
+    pager <- maybe "less -R" (addOpts . words) <$> getEnvMaybe "PAGER"
+    system (pager ++ " " ++ file)
   where
-    addOpts ("less":opts) | "-R" `elem` opts = "less":opts
-    addOpts _                                = ["less", "-R"] 
+    addOpts ("less":opts) | "-R" `elem` opts = unwords ("less":opts)
+    addOpts _                                = "less -R"
 
 --
 -- Clean up the output with some regular expressions.


### PR DESCRIPTION
Before it would try to do rawSystem "less -R" [], which would try to run a file called "less -R", and not have "-R" in its arguments.
