### PR TITLE
Replace pcre-light by regexp-tdfa.

### DIFF
--- a/ghc-core.cabal
+++ b/ghc-core.cabal
@@ -24,7 +24,7 @@ cabal-version:  >= 1.2
 executable ghc-core
     build-depends:  base >= 4 && < 5,
                     process >=1.0.1,
-                    pcre-light,
+                    regex-tdfa,
                     colorize-haskell,
                     directory,
                     filepath

--- a/ghc-core.hs
+++ b/ghc-core.hs
@@ -32,7 +32,7 @@ import System.FilePath
 import System.IO
 import System.Process
 
-import Text.Regex.PCRE.Light.Char8
+import qualified Text.Regex.TDFA as RE
 
 -- BSD-licensed Haskell syntax highlighting, based on Programmatica
 import Language.Haskell.Colorize
@@ -193,3 +193,16 @@ compileWithCore opts args = do
 -- Safe wrapper for getEnv
 getEnvMaybe :: String -> IO (Maybe String)
 getEnvMaybe name = handle (\(_::SomeException) -> return Nothing) (Just <$> getEnv name)
+
+------------------------------------------------------------------------
+
+-- wrappers for regexp operations
+
+compile :: String -> a -> RE.Regex
+compile pat _ = RE.makeRegex pat
+
+match :: RE.Regex -> String -> a -> Maybe [String]
+match regexp s _ = fmap RE.getAllTextSubmatches (RE.matchM regexp s)
+
+ungreedy :: a
+ungreedy = error "hopefully not needed"


### PR DESCRIPTION
The pcre-light package is a binding to a C library, so it is non-trivial to compile on Windows. I think this is the main reason for the "Unix systems only, currently." warning in the package description. In this pull request, I replaced pcre-light with regexp-tdfa (which is pure Haskell), and it compiles fine and seems to work.

Open Questions:
- I ignore the `ungreedy` options. Are they important?
- regexp-tdfa implements Posix regexps, but pcre-light implements Perl-style regexps. Is the difference important for ghc-core?
- Is regexp-tdfa a good choice? It would be easy to use any other library that implements the common regexp API.
